### PR TITLE
Add support for Python 3.13 (the newest supported runtime)

### DIFF
--- a/{{ cookiecutter.project_name }}/template.yaml
+++ b/{{ cookiecutter.project_name }}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             {%- elif cookiecutter.runtime == 'python3.6' %}
             Runtime: python3.6
             {%- else %}
-            Runtime: python3.7
+            Runtime: python3.13
             {%- endif %}
             Events:
                 DynamoDBEvent:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update the default Python Lambda runtime to 3.13. This example application currently tries to use Python 3.7 which no longer works. Note that I didn't modify the `if cookiecutter.runtime` logic for Python 2.7 and 3.6 because I'm not sure what that code is for.

I've tested this by doing `sam init` from my own repository, and doing both a `sam local` and a `sam deploy`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
