### PR TITLE
Update Python runtime from 3.7 to 3.14

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,4 @@
 {
     "project_name": "dynamodb_event_reader",
-    "runtime": "python3.7"
+    "runtime": "python3.14"
 }

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -5,11 +5,7 @@ Sample SAM Template for {{ cookiecutter.project_name }} to interact with DynamoD
 ## Requirements
 
 * AWS CLI already configured with at least PowerUser permission
-{% if cookiecutter.runtime == "python2.7" %}
-* [Python 2 installed](https://www.python.org/downloads/)
-{% else %}
 * [Python 3 installed](https://www.python.org/downloads/)
-{% endif %}
 * [Docker installed](https://www.docker.com/community-edition)
 * [SAM Local installed](https://github.com/awslabs/aws-sam-local)
 

--- a/{{ cookiecutter.project_name }}/template.yaml
+++ b/{{ cookiecutter.project_name }}/template.yaml
@@ -17,13 +17,7 @@ Resources:
         Properties:
             CodeUri: read_dynamodb_event/
             Handler: app.lambda_handler
-            {%- if cookiecutter.runtime == 'python2.7' %}
-            Runtime: python2.7
-            {%- elif cookiecutter.runtime == 'python3.6' %}
-            Runtime: python3.6
-            {%- else %}
-            Runtime: python3.7
-            {%- endif %}
+            Runtime: {{ cookiecutter.runtime }}
             Events:
                 DynamoDBEvent:
                     Type: DynamoDB # More info about DynamoDB Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#dynamodb


### PR DESCRIPTION
## Description

The default Python runtime in this cookiecutter template is python3.7, which has reached end-of-life and is no longer supported by AWS SAM CLI.

This PR updates the default runtime to python3.14 and simplifies the template by removing legacy conditional branches for python2.7 and python3.6.

## Changes

- **cookiecutter.json**: Default runtime updated from `python3.7` to `python3.14`
- **template.yaml**: Removed conditional runtime branches for python2.7/3.6/3.7, now uses `{{ cookiecutter.runtime }}` directly
- **README.md**: Removed python2.7 conditional block since Python 2 is EOL

## Motivation

Reported via feedback: the example uses Python 3.7 which is no longer supported by SAM, causing issues when users try to run the example.